### PR TITLE
Fix code scanning alert no. 17: Database query built from user-controlled sources

### DIFF
--- a/src/controller/middlewareController/createCRUDController/update.js
+++ b/src/controller/middlewareController/createCRUDController/update.js
@@ -1,7 +1,15 @@
 const update = async (Model, req, res) => {
+  // Validate req.body
+  if (typeof req.body !== 'object' || Array.isArray(req.body)) {
+    return res.status(400).json({
+      success: false,
+      result: null,
+      message: 'Invalid request body',
+    });
+  }
   // Find document by id and updates with the required fields
   req.body.removed = false;
-  const result = await Model.findOneAndUpdate({ _id: req.params.id, removed: false }, req.body, {
+  const result = await Model.findOneAndUpdate({ _id: { $eq: req.params.id }, removed: false }, req.body, {
     new: true, // return the new result instead of the old one
     runValidators: true,
   }).exec();


### PR DESCRIPTION
Fixes [https://github.com/Jared3256/shan_eutronNet/security/code-scanning/17](https://github.com/Jared3256/shan_eutronNet/security/code-scanning/17)

To fix the problem, we need to ensure that the user-provided data in `req.body` and `req.params.id` is properly sanitized and validated before being used in the database query. For MongoDB, we can use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. Additionally, we should validate the types of the inputs to ensure they are as expected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
